### PR TITLE
Use node 0.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get -y upgrade && \
     apt-get install -y curl libfreetype6 libfontconfig1 git g++ flex bison \
         gperf ruby perl libsqlite3-dev libfontconfig1-dev libicu-dev \
         libssl-dev libpng-dev libjpeg-dev build-essential python && \
-    curl https://deb.nodesource.com/setup | bash - && \
+    curl https://deb.nodesource.com/setup_0.12 | bash - && \
     apt-get install -y nodejs && \
     apt-get clean && \
     git clone git://github.com/ariya/phantomjs.git && \


### PR DESCRIPTION
This should come with a version of npm that is compatible with the `@namespace` package format. And we're all testing and working off of ndoe 0.12 locally anyway.
